### PR TITLE
feat: particle sharing

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 	},
 	"dependencies": {
 		"bootstrap": "^4.5.3",
+		"fflate": "^0.7.3",
 		"molangjs": "^1.5.0",
 		"prismjs": "^1.28.0",
 		"root": "github:JannisX11/vue-prism-editor",

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,4 +1,5 @@
 import vscode from './vscode_extension'
+import {loadFromUrl} from './share'
 
 if (!vscode) {
     window.onbeforeunload = function() {

--- a/src/browser.js
+++ b/src/browser.js
@@ -15,4 +15,6 @@ if (!vscode) {
     if ('serviceWorker' in navigator) {
         registerSW();
     }
+
+    loadFromUrl()
 }

--- a/src/components/Icons/Share.vue
+++ b/src/components/Icons/Share.vue
@@ -1,0 +1,4 @@
+
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1em" height="1em" viewBox="0 0 24 24"><path fill="currentColor" d="m21 12l-7-7v4C7 10 4 15 3 20c2.5-3.5 6-5.1 11-5.1V19l7-7Z"></path></svg>
+</template>

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -8,6 +8,7 @@
                 </li>
             </ul>
         </li>
+		
 		<template v-if="isVSCExtension">
         	<li class="mode_selector" @click="openCodeViewer(true)" title="Open Code View to Side"><i class="unicode_icon split">{{'\u2385'}}</i></li>
         	<li class="mode_selector" @click="openCodeViewer(false)" title="Open as Code View">Switch to Code</li>
@@ -16,6 +17,10 @@
         	<li class="mode_selector code" :class="{selected: selected_tab == 'code'}" @click="$emit('changetab', 'code')">Code</li>
         	<li class="mode_selector preview" :class="{selected: selected_tab == 'preview'}" @click="$emit('changetab', 'preview')">Preview</li>
 		</template>
+
+		<div v-if="canShare" @click="onShareParticle" class="mode_selector">
+			<Share style="font-size: 24px;" />
+		</div>
     </ul>
 </template>
 
@@ -25,6 +30,10 @@ import {importFile,	loadPreset,	startNewProject} from '../import'
 import {View} from './Preview'
 
 import vscode from '../vscode_extension'
+import Share from './Icons/Share.vue'
+import { shareParticle } from '../share'
+import { generateFile } from '../export'
+import Data from '../input_structure'
 const isVSCExtension = !!vscode;
 
 function openLink(link) {
@@ -91,6 +100,7 @@ if (!isVSCExtension) {
 
 export default {
     name: 'menu-bar',
+	components: { Share },
     props: {
         selected_tab: String,
         portrait_view: Boolean
@@ -109,11 +119,25 @@ export default {
 		},
 		getVM() {
 			return this;
+		},
+		onShareParticle() {
+			let rawImg = null
+
+			const imageInput = Data.particle.texture.inputs.image
+			const dataUrl = imageInput.image.data
+			if(dataUrl) {
+				const base64 = dataUrl.split(',')[1]
+				rawImg = Uint8Array.from(atob(base64), c => c.charCodeAt(0))
+			}
+			
+
+			shareParticle(generateFile(), rawImg)
 		}
 	},
 	data() {return {
 		Menu,
-		isVSCExtension
+		isVSCExtension,
+		canShare: 'share' in navigator,
 	}}
 }
 </script>

--- a/src/import.js
+++ b/src/import.js
@@ -51,8 +51,8 @@ function updateConfig(data) {
 	Config.setFromJSON(data);
 	updateInputsFromConfig();
 }
-function loadFile(data) {
-	if (data && data.particle_effect && startNewProject()) {
+function loadFile(data, confirmNewProject=true) {
+	if (data && data.particle_effect && (!confirmNewProject || startNewProject())) {
 		updateConfig(data);
 		Emitter.stop(true).playLoop();
 		registerEdit('load file')

--- a/src/input.js
+++ b/src/input.js
@@ -94,7 +94,8 @@ export default class Input {
 	change(e, node) {
 		var scope = this;
 		if (this.type === 'image' && e) {
-			var file = e.target.files[0];
+			var file = e instanceof Uint8Array ? new File([e], 'unknown.png') : e.target.files[0];
+
 			if (file) {
 				var reader = new FileReader()
 				reader.onloadend = function() {
@@ -124,7 +125,7 @@ export default class Input {
 			this.updatePreview(this.value)
 		}
 		let color_input_sliding = this.type == 'color' && node && node.querySelector('.input_wrapper[input_type="color"]:active');
-		if (e instanceof Event || (this.type == 'color' && node))	{
+		if (e instanceof Event || e instanceof Uint8Array || (this.type == 'color' && node))	{
 			// User Input
 			if (ExpandedInput.setup && ['molang', 'text'].includes(this.type)) {
 				this.updateExpressionBar(false);

--- a/src/share.js
+++ b/src/share.js
@@ -1,0 +1,66 @@
+import { loadFile } from './import'
+import { strFromU8, strToU8, zlibSync, unzlibSync } from "fflate"
+import Data from './input_structure'
+
+/**
+ * Share a particle by encoding it within the url
+ * @param {any} particle 
+ * @param {Uint8Array} texture 
+ */
+export async function shareParticle(particle, texture) {
+    const url = new URL(window.location.href)
+
+    url.searchParams.set(
+        'loadParticle',
+        btoa(
+            strFromU8(
+                zlibSync(strToU8(JSON.stringify(particle), true), {
+                    level: 9,
+                }),
+                true
+            )
+        )
+    )
+    if(texture !== null) {
+        url.searchParams.set(
+            'loadParticleTexture', 
+            btoa(
+                strFromU8(
+                    zlibSync(texture, {
+                        level: 9,
+                    }),
+                    true
+                )
+            )
+        )
+    }
+        
+    await navigator
+        .share({
+            title: particle.particle_effect.description.identifier ?? 'Unknown',
+            text: 'View this particle with Snowstorm',
+            url: url.href,
+        })
+        .catch(() => {})
+}
+
+export async function loadFromUrl() {
+    const url = new URLSearchParams(window.location.search)
+
+    if (url.has('loadParticle')) {
+        const compressed = strToU8(atob(url.get('loadParticle')), true)
+        const decompressed = unzlibSync(compressed)
+        const particle = JSON.parse(strFromU8(decompressed))
+        
+        loadFile(particle, false)
+    }
+
+    if(url.has('loadParticleTexture')) {
+        const compressed = strToU8(atob(url.get('loadParticleTexture')), true)
+        const decompressed = unzlibSync(compressed)
+        const texture = decompressed
+
+        const imageInput = Data.particle.texture.inputs.image
+        imageInput.change(texture)
+    }
+}

--- a/src/share.js
+++ b/src/share.js
@@ -44,6 +44,9 @@ export async function shareParticle(particle, texture) {
         .catch(() => {})
 }
 
+/**
+ * Upon starting Snowstorm, try to load particle data from the url
+ */
 export async function loadFromUrl() {
     const url = new URLSearchParams(window.location.search)
 


### PR DESCRIPTION
## Motivation
Allow users to easily share particles with other people. This works by encoding the particle JSON and texture data within the URL.

## Description
This PR mainly consists of two parts:
1) Inside of a browser env, try to load an encoded particle from the URL
2) New "Share" button which allows users to encode their particle and share it with other users.
<img width="473" alt="New Share Button" src="https://user-images.githubusercontent.com/33347616/177141193-444fc367-47fe-4ec1-a51a-c50bc931de2c.png">