### PR TITLE
Fix 'query.camera_distance_range_lerp'.

### DIFF
--- a/src/emitter.js
+++ b/src/emitter.js
@@ -130,7 +130,17 @@ Emitter.Molang.global_variables = {
 	},
 	'query.camera_distance_range_lerp'(a, b) {
 		let distance = View.camera.position.length();
-		return Math.clamp(Math.getLerp(a, b, distance), 0, 1);
+		// Prevent division by zero
+		const denominator = b - a;
+		if (Math.abs(denominator) < 1e-8) {
+			if (distance < a) {
+				return 0;
+			} else {
+				return 1;
+			}
+		}
+		// Interpolation of x between 0 and 1 in range [a, b]: (x-a)/(b-a)
+		return Math.clamp((distance - a) / denominator, 0, 1);
 	}
 }
 


### PR DESCRIPTION
I found that `q.camera_distance_range_lerp` wasn't implemented correctly. It used `Math.getLerp` function which I don't think exists (?). I fixed it by implementing lerp with regular math operations.

Notes:
- This function takes `a` and `b` as input and returns values in range `0` to `1`. It's like reversed `math.lerp` which takes `a`, `b`, and interpolation value between `0` and `1` and returns value in range `a` to `b`.
- I'm not sure if I selected the correct base for PR.
- The build process creates some additional files that aren't in `.gitignore`. I only pushed the source change.