### PR TITLE
Fix #112

### DIFF
--- a/vscode_extension/src/snowstormEditor.js
+++ b/vscode_extension/src/snowstormEditor.js
@@ -294,9 +294,6 @@ module.exports.SnowstormEditorProvider = class SnowstormEditorProvider {
 						margin: 0;
 						padding: 0;
 					}
-					#app {
-						margin-left: -20px;
-					}
 				</style>
 			</head>
 			<body>


### PR DESCRIPTION
This fixes the issue of the main workspace window being offset to the left by -20px.

It seems like this negative margin has been here from the earliest commits on this repo, so I can only assume that this was in place to fix a quirk with VSCode at that time. /shrug