### PR TITLE
Add "Switch to Snowstorm" button to editor menu

### DIFF
--- a/vscode_extension/package.json
+++ b/vscode_extension/package.json
@@ -12,7 +12,8 @@
 		"Other"
 	],
 	"activationEvents": [
-		"onCustomEditor:x11.snowstorm"
+		"onCustomEditor:x11.snowstorm",
+		"onCommand:snowstorm.switchToSnowstorm"
 	],
 	"repository": {
 		"type": "git",
@@ -21,6 +22,21 @@
 	"license": "GPL-3.0-or-later",
 	"main": "./src/extension.js",
 	"contributes": {
+		"commands": [
+			{
+				"command": "snowstorm.switchToSnowstorm",
+				"title": "Switch to Snowstorm"
+			}
+		],
+		"menus": {
+			"editor/title": [
+				{
+					"command": "snowstorm.switchToSnowstorm",
+					"when": "resourceFilename =~ /\\.particle\\.json$/ && activeCustomEditorId != x11.snowstorm",
+					"group": "navigation"
+				}
+			]
+		},
 		"customEditors": [
 			{
 				"viewType": "x11.snowstorm",

--- a/vscode_extension/src/extension.js
+++ b/vscode_extension/src/extension.js
@@ -1,7 +1,16 @@
+const vscode = require('vscode')
 const {SnowstormEditorProvider} = require('./snowstormEditor')
 
 function activate(context) {
-	context.subscriptions.push(new SnowstormEditorProvider(context).getRegistration());
+	context.subscriptions.push(
+		new SnowstormEditorProvider(context).getRegistration(),
+		vscode.commands.registerCommand('snowstorm.switchToSnowstorm', uri => {
+			const resource = uri || vscode.window.activeTextEditor?.document.uri
+			if (resource) {
+				return vscode.commands.executeCommand('vscode.openWith', resource, 'x11.snowstorm')
+			}
+		})
+	)
 }
 
 exports.activate = activate;


### PR DESCRIPTION
Adds a convenient button to switch between editor types.

Preview:

https://github.com/user-attachments/assets/84472dcb-97be-49a3-a176-ec16529ec83e

